### PR TITLE
(WIP) Propagate errors in handle_connection, add RL error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,10 @@ pub mod request;
 pub mod response;
 use method::Method;
 use request::{parse_request_line, Request};
-use response::*;
+use response::response;
 
 use log::{error, info};
 use std::error::Error;
-use std::io;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::{error, fmt};
@@ -18,12 +17,6 @@ struct RequestLineNotFound;
 impl fmt::Display for RequestLineNotFound {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Request-Line not found")
-    }
-}
-
-impl From<io::Error> for RequestLineNotFound {
-    fn from(error: io::Error) -> Self {
-        RequestLineNotFound
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,18 +7,37 @@ use response::*;
 
 use log::{error, info};
 use std::error::Error;
+use std::io;
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::{error, fmt};
+
+#[derive(Debug)]
+struct RequestLineNotFound;
+
+impl fmt::Display for RequestLineNotFound {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Request-Line not found")
+    }
+}
+
+impl From<io::Error> for RequestLineNotFound {
+    fn from(error: io::Error) -> Self {
+        RequestLineNotFound
+    }
+}
+
+impl error::Error for RequestLineNotFound {}
 
 #[allow(clippy::unused_io_amount)]
 pub fn handle_connection(mut stream: TcpStream) -> Result<(), Box<dyn Error>> {
     let mut buffer = vec![0u8; 1024];
 
     // writes stream into buffer
-    stream.read(&mut buffer).unwrap();
+    stream.read(&mut buffer)?;
 
     let request = String::from_utf8_lossy(&buffer[..]);
-    let request_line = request.lines().next().expect("Request line doesn't exist");
+    let request_line = request.lines().next().ok_or(RequestLineNotFound)?;
     info!("Request-Line: {}", &request_line);
 
     // Get response from request_line
@@ -33,10 +52,8 @@ pub fn handle_connection(mut stream: TcpStream) -> Result<(), Box<dyn Error>> {
     match response {
         Ok(mut response) => {
             info!("Response: {}", response);
-            stream
-                .write(&response.format_response())
-                .expect("Couldn't write response");
-            stream.flush().expect("Error flushing stream");
+            stream.write(&response.format_response())?;
+            stream.flush()?;
         }
         Err(e) => error!("Response error: {}", e),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub fn handle_connection(mut stream: TcpStream) -> Result<(), Box<dyn Error>> {
 
     match response {
         Ok(mut response) => {
-            info!("Response: {}", response);
+            info!("Response-Line: {}", response);
             stream.write(&response.format_response())?;
             stream.flush()?;
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -126,6 +126,7 @@ fn add_file(path: &str, head: bool) -> Result<Response, Box<dyn Error>> {
     }
 }
 
+/// Process Request, returning a Response
 pub fn response(request: &Request) -> Result<Response, Box<dyn Error>> {
     match *request.method() {
         Method::GET => add_file(
@@ -158,6 +159,7 @@ impl Response {
         }
     }
 
+    /// Format Response object and return it as bytes to write to a buffer
     pub fn format_response(&mut self) -> Vec<u8> {
         // Append Status-Line
         // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
@@ -182,15 +184,7 @@ impl Response {
 
 impl fmt::Display for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // Append Status-Line
         // Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF
-        let mut result = format!("HTTP/1.1 {}\r\n", self.status);
-
-        // Append Content-Type entity-header
-        if let Some(content_type) = &self.headers.content_type {
-            result = format!("{}Content-type: {}\r\n\r\n", result, content_type.as_str());
-        }
-
-        writeln!(f, "{}", result)
+        writeln!(f, "HTTP/1.1 {}", self.status)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -114,7 +114,7 @@ fn add_file(path: &str, head: bool) -> Result<Response, Box<dyn Error>> {
                     // check if method type is not HEAD
                     if !head {
                         response.body =
-                            Some(fs::read(format!("{}/404.html", root)).unwrap_or(vec![]));
+                            Some(fs::read(format!("{}/404.html", root)).unwrap_or_else(|_| vec![]));
                     }
                     StatusCode::NOT_FOUND
                 }


### PR DESCRIPTION
Now propagates errors with `?` new RequestLineNotFound error gets sent
back if the Request-Line does not exist.